### PR TITLE
Added optional parameters to entityproperty. Fixed readme typos. formatting

### DIFF
--- a/Emerson.EdgeClient/Emerson.EdgeClient.Authentication/Emerson.EdgeClient.Authentication.csproj
+++ b/Emerson.EdgeClient/Emerson.EdgeClient.Authentication/Emerson.EdgeClient.Authentication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Emerson.EdgeClient/Emerson.EdgeClient.Authentication/HttpClientTokenRequestExtensions.cs
+++ b/Emerson.EdgeClient/Emerson.EdgeClient.Authentication/HttpClientTokenRequestExtensions.cs
@@ -25,12 +25,12 @@ namespace Emerson.EdgeClient.Authentication
         private static async Task<TokenResponse> RequestTokenAsync(HttpClient client, Credentials credentials, CancellationToken cancellationToken)
         {
             var tokenResponse = new TokenResponse();
-            
+
             var content = new[]
             {
-                    new KeyValuePair<string, string>("Username", credentials.Username),
-                    new KeyValuePair<string, string>("Password", credentials.Password)
-                };
+                new KeyValuePair<string, string>("Username", credentials.Username),
+                new KeyValuePair<string, string>("Password", credentials.Password)
+            };
 
             // Get data response
             var response = await client.PostAsync(authUrl, new FormUrlEncodedContent(content), cancellationToken);

--- a/Emerson.EdgeClient/Emerson.EdgeClient.Graph/Emerson.EdgeClient.Graph.csproj
+++ b/Emerson.EdgeClient/Emerson.EdgeClient.Graph/Emerson.EdgeClient.Graph.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageId>DeltaV.EdgeClient.Graph</PackageId>

--- a/Emerson.EdgeClient/Emerson.EdgeClient.Graph/Models/Entity.cs
+++ b/Emerson.EdgeClient/Emerson.EdgeClient.Graph/Models/Entity.cs
@@ -17,8 +17,10 @@ namespace Emerson.EdgeClient.Graph.Models
 
     public class EntityProperty
     {
-        public string Type { get; set; }
-        public object Value { get; set; }
+        public required string Type { get; set; }
+        public required object Value { get; set; }
+        public string? History { get; set; }
+        public string? Timestamp { get; set; }
     }
 
     public class RelationshipProperties

--- a/Emerson.EdgeClient/Emerson.EdgeClient.History/Emerson.EdgeClient.History.csproj
+++ b/Emerson.EdgeClient/Emerson.EdgeClient.History/Emerson.EdgeClient.History.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ var user = "user"; //add your REST API username here
 var pass = "pass"; //add your REST API password here
 
 client.BaseAddress = new Uri(edgeUrl);
-var token = await edgeClient.RequestClientTokenAsync(new Emerson.EdgeClient.Authentication.Models.Credentials()
-        {
-            Username = user,
-            Password = pass
-        });
+var token = await client.RequestClientTokenAsync(new Emerson.EdgeClient.Authentication.Models.Credentials()
+{
+    Username = user,
+    Password = pass
+});
 
-edgeClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.AccessToken);
+client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.AccessToken);
 
 ```
 
@@ -91,7 +91,7 @@ var history = await client.GetAeAsync(pageSize, pageNumber);
 ```
 
 # Sample Clients
-You may check our sample codes to understand how it works.
+Check out our sample code here to learn more.
   * [ConsoleApp](./samples/ConsoleApp/readme.md)
 
 # Authors


### PR DESCRIPTION
- EntityProperty can have a history string and timestamp returned, so an optional field was created to reflect that.
- Made the sample code error-free in readme
- Updated projects to net8.0 for consistency and "required" keyword c# feature (.net7 and up only)